### PR TITLE
H-4073: Enable `lockFileMaintenance` in default Renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -21,6 +21,12 @@
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
   "dependencyDashboardTitle": "🚀 Dependency Updates",
+  "lockFileMaintenance": { 
+    "enabled": true,
+    "branchTopic": "lock-regenerate",
+    "commitMessageAction": "Regenerate lock files",
+    "schedule": ["before 4am on sunday"]
+  },
   "npm": {
     "minimumReleaseAge": "3 days"
   },


### PR DESCRIPTION
### Context

See [this comment](https://github.com/renovatebot/renovate/discussions/17970) explaining why it's a good idea in principle, and the [Renovate docs](https://docs.renovatebot.com/faq/#keep-lock-files-including-sub-dependencies-up-to-date-even-when-packagejson-hasnt-changed).

### This PR

This PR enables `lockFileMaintenance` on a weekly schedule, running outside of office hours on a Sunday morning, to see if it's useful. We can disable this rule if it causes issues or inadvertently increases maintenance headaches.

### FAO

@TimDiekmann If you disagree, or want to scope this to a particular package manager (e.g. exclude `Cargo.toml`), please see the [`lockFileMaintenance` config options](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance).