### PR TITLE
H-4111, H-4112: Group `Cedar` crates updates in Renovate

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -284,6 +284,11 @@
     },
     {
       "matchManagers": ["cargo"],
+      "groupName": "`cedar-policy` Rust crates",
+      "matchPackageNames": ["/^cedar-policy[-_]?/"]
+    },
+    {
+      "matchManagers": ["cargo"],
       "groupName": "`clap` Rust crates",
       "matchPackageNames": ["/^clap[-_]?/"]
     },


### PR DESCRIPTION
Cedar-crates needs to be updated at the same time. Also, they strongly belong to each other.