### PR TITLE
H-4136: Move repository-specific renovate rules out of .github

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -344,12 +344,6 @@
       "matchManagers": ["cargo"],
       "groupName": "`libp2p` Rust crates",
       "matchPackageNames": ["/^libp2p[-_]?/"]
-    },
-    {
-      "matchManagers": ["cargo"],
-      "matchFileNames": ["libs/error-stack/Cargo.toml"],
-      "matchPackageNames": ["anyhow"],
-      "enabled": false
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Only the `hashintel/hash` repository defines the `error-stack` crate. This rule only apply to that repository.