### PR TITLE
H-4074: Lint the Renovate config in .github repo CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  pull_request:
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  renovate:
+    name: Validate renovate config
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate renovate config
+        run: |
+          npm install --global renovate
+          if ! renovate-config-validator; then
+            echo ''
+            echo ''
+            echo 'ℹ️ ℹ️ ℹ️'
+            echo 'Please fix the above errors locally for the check to pass.'
+            echo 'If you don’t see them, try merging target branch into yours.'
+            echo 'ℹ️ ℹ️ ℹ️'
+            exit 1
+          fi

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2021 HASH
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-## Welcome to HASH 👋
+# Welcome to HASH 👋
 
 This is HASH's default [community health repo](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).
 
-
-### What is this
+## What is this
 
 This repo will contain default files for all HASH OSS repos and will be extended to include:
+
 - Basic issue templates, covering Bug Reports and Feature Requests
 - A PR template
 - Our contributions guide: `CONTRIBUTING.md`


### PR DESCRIPTION
The renovate configuration should be linted in CI.

Drive-by: Apply `markdownlint` to markdown files