### PR TITLE
H-4156: Exclude `@effect/vitest` from `@effect` in renovate

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -171,7 +171,12 @@
     {
       "groupName": "`effect` npm packages",
       "matchManagers": ["npm"],
-      "matchPackageNames": ["/^@effect//", "/^effect-/", "/effect$/"]
+      "matchPackageNames": [
+        "/^@effect//",
+        "/^effect-/",
+        "/effect$/",
+        "!/@effect/vitest/"
+      ]
     },
     {
       "groupName": "`graphql` npm packages",


### PR DESCRIPTION
They should be updated together with vitest instead