### PR TITLE
H-4985: Add `indicatif` as dependency group

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -321,6 +321,11 @@
     },
     {
       "matchManagers": ["cargo"],
+      "groupName": "`indicatif` Rust crates",
+      "matchPackageNames": ["/^indicatif[-_]?/", "/-indicatif$/"]
+    },
+    {
+      "matchManagers": ["cargo"],
       "groupName": "`napi` Rust crates",
       "matchPackageNames": ["/^napi[-_]?/"]
     },


### PR DESCRIPTION
`indicatif` and `tracing-indicatif` should be updated alongside, see
- https://github.com/hashintel/hash/pull/7578
- https://github.com/hashintel/hash/pull/7605