### PR TITLE
Remove redundant GitHub banner link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,6 @@
 <!-- GitHub links -->
 [block protocol]: https://github.com/blockprotocol/blockprotocol
 [hash]: https://github.com/hashintel/hash
-[github_banner]: #welcome-to-hash-
 
 <!-- Social links -->
 [𝕏]: https://x.com/hashintel


### PR DESCRIPTION
Removes deprecated GitHub banner link from README.