### PR TITLE
BE-170: Add a `Temporal` cargo group for dependency bumps

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -376,6 +376,11 @@
       "matchManagers": ["cargo"],
       "groupName": "`libp2p` Rust crates",
       "matchPackageNames": ["/^libp2p[-_]?/"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "`Temporal` Rust crates",
+      "matchPackageNames": ["/^temporal[-_]?/"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Added a new package group for Temporal Rust crates in the Renovate configuration. This allows Renovate to group updates for all Temporal-related Rust packages together, similar to the existing group for libp2p crates.

