### PR TITLE
SRE-279: Increase Renovate PR concurrent limit from 15 to 25

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -29,7 +29,7 @@
   "semanticCommits": "disabled",
   "schedule": ["before 4am every weekday", "every weekend"],
   "assigneesFromCodeOwners": true,
-  "prConcurrentLimit": 15,
+  "prConcurrentLimit": 25,
   "branchConcurrentLimit": 0,
   "packageRules": [
     {


### PR DESCRIPTION
Increase Renovate PR concurrent limit from 15 to 25

This change increases the maximum number of concurrent PRs that Renovate can create from 15 to 25, allowing more dependency updates to be processed simultaneously.
