### PR TITLE
H-6228: Add match for 'temporalio' in Renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -385,7 +385,7 @@
     {
       "matchManagers": ["cargo"],
       "groupName": "`Temporal` Rust crates",
-      "matchPackageNames": ["/^temporal[-_]?/"]
+      "matchPackageNames": ["/^temporal[-_]?/", "/^temporalio[-_]?/"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
See https://github.com/hashintel/hash/pull/8415 and https://github.com/hashintel/hash/pull/8421