### PR TITLE
SRE-411: Fix Temporal Rust crates pattern in Renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -380,7 +380,7 @@
     {
       "matchManagers": ["cargo"],
       "groupName": "`Temporal` Rust crates",
-      "matchPackageNames": ["/^temporal[-_]?/"]
+      "matchPackageNames": ["/^temporalio[-_]?/"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Updated the regex pattern in the Renovate configuration to match Rust crates with the prefix `temporalio` instead of `temporal`. This change ensures that the Renovate bot correctly groups Temporal-related Rust dependencies under the "`Temporal` Rust crates" group.
