### PR TITLE
SRE-527: Add Terraform and TFLint Renovate rules

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -74,6 +74,29 @@
       "assignees": ["TimDiekmann", "indietyp"]
     },
     {
+      "description": "Terraform providers",
+      "matchManagers": ["terraform"],
+      "matchDepTypes": ["provider"],
+      "additionalBranchPrefix": "tf/",
+      "commitMessageTopic": "Terraform provider `{{depName}}`",
+      "dependencyDashboardApproval": false,
+      "assignees": ["TimDiekmann"]
+    },
+    {
+      "description": "Don't auto-bump terraform required_version (controlled via mise)",
+      "matchManagers": ["terraform"],
+      "matchDepTypes": ["required_version"],
+      "enabled": false
+    },
+    {
+      "description": "TFLint plugins",
+      "matchManagers": ["tflint-plugin"],
+      "additionalBranchPrefix": "tflint/",
+      "commitMessageTopic": "TFLint plugin `{{depName}}`",
+      "dependencyDashboardApproval": false,
+      "assignees": ["TimDiekmann"]
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "dependencyDashboardApproval": false,
       "assignees": ["TimDiekmann", "indietyp"],


### PR DESCRIPTION
## Summary

Add shared Renovate package rules for Terraform-based repos:

- **Terraform providers**: branch prefix `deps/tf/`, no dashboard approval, assigned to @TimDiekmann
- **required_version**: disabled (Terraform CLI version controlled via mise)
- **TFLint plugins**: branch prefix `deps/tflint/`, no dashboard approval, assigned to @TimDiekmann

Part of setting up Renovate in `hashintel/internal-infra`.

## Test plan

- [ ] Merge this, then verify internal-infra Renovate picks up the rules from shared config