### PR TITLE
SRE-603: Apply minimumReleaseAge globally instead of npm-only

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -21,9 +21,7 @@
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
   "dependencyDashboardTitle": "🚀 Dependency Updates",
-  "npm": {
-    "minimumReleaseAge": "3 days"
-  },
+  "minimumReleaseAge": "3 days",
   "postUpdateOptions": ["yarnDedupeHighest"],
   "rebaseWhen": "conflicted",
   "semanticCommits": "disabled",

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -140,8 +140,6 @@
       "matchManagers": ["npm"],
       "automerge": false,
       "dependencyDashboardApproval": false,
-      "minimumReleaseAge": "0 days",
-      "schedule": ["after 1am"],
       "matchPackageNames": ["/^@openai//", "/^@anthropic-ai//", "/groq-sdk/"]
     },
     {


### PR DESCRIPTION
## Summary

- Move `minimumReleaseAge: 3 days` from npm-specific to top-level config
- All dependency managers (mise, cargo, terraform, github-actions, docker, tflint-plugin) now wait 3 days before Renovate proposes bumps
- Remove `minimumReleaseAge: 0 days` and `schedule: after 1am` overrides from LLM SDK packages — no reason to pull SDK updates on day 0