### PR TITLE
H-6392: Add reusable dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,9 @@ name: Dependency Review
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/dependency-review.yml"
+  pull_request_target:
   merge_group:
   workflow_call:
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,32 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required, PRs introducing
+# known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
+name: Dependency Review
+
+on:
+  pull_request:
+  merge_group:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          comment-summary-in-pr: on-failure
+          show-patched-versions: true


### PR DESCRIPTION
## Summary
- Adds a centralized `dependency-review` reusable workflow for the org
- Runs on `pull_request`, `merge_group`, and `workflow_call`
- Configures `comment-summary-in-pr: on-failure` and `show-patched-versions: true`
- Bumps `dependency-review-action` to v4.9.0 (Node.js 24 compatible)

## Related
- [H-6392](https://linear.app/hash/issue/H-6392)
- hashintel/hash#8599 — caller workflow for hash repo