### PR TITLE
H-6390: Increase minimumReleaseAge from 3 to 14 days

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -21,7 +21,7 @@
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
   "dependencyDashboardTitle": "🚀 Dependency Updates",
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "14 days",
   "postUpdateOptions": ["yarnDedupeHighest"],
   "rebaseWhen": "conflicted",
   "semanticCommits": "disabled",


### PR DESCRIPTION
## Summary
- Increases the global `minimumReleaseAge` from 3 days to 14 days
- Reduces risk of adopting broken or malicious releases across all ecosystems