### PR TITLE
H-6402: Add preflight reusable workflows

### DIFF
--- a/.github/actions/dismiss-stale-approvals/action.yml
+++ b/.github/actions/dismiss-stale-approvals/action.yml
@@ -1,0 +1,195 @@
+name: Dismiss stale approvals
+description: Dismiss approvals on a pull request if the diff has changed
+
+inputs:
+  github-token:
+    description: A GITHUB_TOKEN secret or PAT that has write access to the repository
+    required: true
+  fetch-depth:
+    default: 250
+    description: The maximum length of a branch from head to base that will be compared to the previous run
+    required: false
+  dry-run:
+    description: Comment on the PR instead of dismissing approvals
+    required: false
+    default: false
+
+outputs:
+  stale:
+    description: Whether approvals should be dismissed
+    value: ${{ steps.decision.outputs.stale }}
+  reason:
+    description: The dismissal reason
+    value: ${{ steps.decision.outputs.reason }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set workflow run URL
+      id: run-url
+      shell: bash
+      run: |
+        repo_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+        run_url="$repo_url/actions/runs/${GITHUB_RUN_ID}"
+        echo "workflow_run_url=$run_url" >> "$GITHUB_OUTPUT"
+
+    - name: Download SHAs from last run
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        ACTION_PATH: ${{ github.action_path }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        HEAD_REF: ${{ github.head_ref }}
+        REPOSITORY: ${{ github.repository }}
+        WORKFLOW_NAME: ${{ github.workflow }}
+      run: |
+        "$ACTION_PATH/latest-artifact.sh" \
+          "$REPOSITORY" \
+          "$PR_NUMBER" \
+          "$HEAD_REF" \
+          "$WORKFLOW_NAME" \
+          "dismiss-stale-approvals-shas" || true
+
+        if [[ -f shas.txt ]]; then
+          echo "PREV_HEAD_SHA=$(head -n 1 shas.txt)" >> "$GITHUB_ENV"
+          echo "PREV_BASE_SHA=$(tail -n 1 shas.txt)" >> "$GITHUB_ENV"
+        else
+          echo "NO_PREV_SHAS=1" >> "$GITHUB_ENV"
+        fi
+
+    - name: Read SHAs
+      shell: bash
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+        echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_ENV"
+
+    - name: Write SHAs to file
+      shell: bash
+      run: |
+        echo "$HEAD_SHA" > shas.txt
+        echo "$BASE_SHA" >> shas.txt
+
+    - name: Upload SHAs
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      continue-on-error: true
+      with:
+        name: dismiss-stale-approvals-shas
+        path: shas.txt
+
+    - name: Check if diff has changed
+      id: range-diff
+      continue-on-error: true
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        FETCH_DEPTH: ${{ inputs.fetch-depth }}
+        FETCHED_REPOSITORY_PATH: bare.git
+        GH_TOKEN: ${{ inputs.github-token }}
+        PREV_BASE_SHA: ${{ env.PREV_BASE_SHA }}
+        PREV_HEAD_SHA: ${{ env.PREV_HEAD_SHA }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        if [[ "${NO_PREV_SHAS:-0}" == "1" ]]; then
+          echo "stale=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        git init -q --bare "$FETCHED_REPOSITORY_PATH"
+        git -C "$FETCHED_REPOSITORY_PATH" remote add origin "https://oauth2:${GH_TOKEN}@github.com/${REPOSITORY}.git"
+        git -C "$FETCHED_REPOSITORY_PATH" fetch -q origin --depth="$FETCH_DEPTH" \
+          "$PREV_BASE_SHA" \
+          "$PREV_HEAD_SHA" \
+          "$BASE_SHA" \
+          "$HEAD_SHA"
+
+        prev_merge_base="$(git -C "$FETCHED_REPOSITORY_PATH" merge-base "$PREV_BASE_SHA" "$PREV_HEAD_SHA")"
+        merge_base="$(git -C "$FETCHED_REPOSITORY_PATH" merge-base "$BASE_SHA" "$HEAD_SHA")"
+        range_diff="$(git -C "$FETCHED_REPOSITORY_PATH" range-diff "$prev_merge_base..$PREV_HEAD_SHA" "$merge_base..$HEAD_SHA")"
+
+        printf '%s\n' "$range_diff" | "$ACTION_PATH/range-diff-stale.sh" >> "$GITHUB_OUTPUT"
+
+    - name: Read latest approval SHA
+      id: approval
+      continue-on-error: true
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        approval_sha="$("$ACTION_PATH/latest-approval-sha.sh" "$REPOSITORY" "$PR_NUMBER")"
+        echo "sha=$approval_sha" >> "$GITHUB_OUTPUT"
+
+    - name: Check for manual merge resolutions after approval
+      id: merge-tree
+      continue-on-error: true
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        APPROVAL_SHA: ${{ steps.approval.outputs.sha }}
+        FETCH_DEPTH: ${{ inputs.fetch-depth }}
+        FETCHED_REPOSITORY_PATH: bare.git
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        if [[ ! -d "$FETCHED_REPOSITORY_PATH" ]]; then
+          git init -q --bare "$FETCHED_REPOSITORY_PATH"
+          git -C "$FETCHED_REPOSITORY_PATH" remote add origin "https://oauth2:${GH_TOKEN}@github.com/${REPOSITORY}.git"
+        fi
+
+        fetch_refs=("$HEAD_SHA")
+        if [[ -n "$APPROVAL_SHA" ]]; then
+          fetch_refs+=("$APPROVAL_SHA")
+        fi
+
+        git -C "$FETCHED_REPOSITORY_PATH" fetch -q origin --depth="$FETCH_DEPTH" "${fetch_refs[@]}"
+
+        "$ACTION_PATH/check-manual-merge-resolutions.sh" \
+          --repository-path "$FETCHED_REPOSITORY_PATH" \
+          --approval-sha "$APPROVAL_SHA" \
+          --head-sha "$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
+    - name: Decide whether approvals are stale
+      id: decision
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        APPROVAL_OUTCOME: ${{ steps.approval.outcome }}
+        MERGE_TREE_OUTCOME: ${{ steps.merge-tree.outcome }}
+        MERGE_TREE_REASON: ${{ steps.merge-tree.outputs.reason }}
+        MERGE_TREE_STALE: ${{ steps.merge-tree.outputs.stale }}
+        NO_PREV_SHAS: ${{ env.NO_PREV_SHAS }}
+        RANGE_DIFF_OUTCOME: ${{ steps.range-diff.outcome }}
+        RANGE_DIFF_STALE: ${{ steps.range-diff.outputs.stale }}
+        WORKFLOW_RUN_URL: ${{ steps.run-url.outputs.workflow_run_url }}
+      run: |
+        "$ACTION_PATH/decide-stale-approvals.sh" \
+          --approval-outcome "$APPROVAL_OUTCOME" \
+          --merge-tree-outcome "$MERGE_TREE_OUTCOME" \
+          --merge-tree-stale "$MERGE_TREE_STALE" \
+          --merge-tree-reason "$MERGE_TREE_REASON" \
+          --range-diff-outcome "$RANGE_DIFF_OUTCOME" \
+          --range-diff-stale "$RANGE_DIFF_STALE" \
+          --no-prev-shas "${NO_PREV_SHAS:-0}" \
+          --workflow-run-url "$WORKFLOW_RUN_URL" >> "$GITHUB_OUTPUT"
+
+    - name: Dismiss approvals
+      if: steps.decision.outputs.stale == 'true'
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REASON: ${{ steps.decision.outputs.reason }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        "$ACTION_PATH/dismiss-reviews.sh" \
+          --repository "$REPOSITORY" \
+          --pr-number "$PR_NUMBER" \
+          --reason "$REASON" \
+          --dry-run "$DRY_RUN"

--- a/.github/actions/dismiss-stale-approvals/action.yml
+++ b/.github/actions/dismiss-stale-approvals/action.yml
@@ -73,7 +73,7 @@ runs:
         echo "$BASE_SHA" >> shas.txt
 
     - name: Upload SHAs
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       continue-on-error: true
       with:
         name: dismiss-stale-approvals-shas

--- a/.github/actions/dismiss-stale-approvals/check-manual-merge-resolutions.sh
+++ b/.github/actions/dismiss-stale-approvals/check-manual-merge-resolutions.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_git() {
+  local repository_path="$1"
+  shift
+
+  git -C "$repository_path" "$@"
+}
+
+run_check_manual_merge_resolutions() {
+  local repository_path="$1"
+  local approval_sha="$2"
+  local head_sha="$3"
+
+  if [[ -z "$approval_sha" || -z "$head_sha" ]]; then
+    printf 'stale=false\nreason=\n'
+    return 0
+  fi
+
+  if ! run_git "$repository_path" rev-parse --verify --quiet "$approval_sha^{commit}" >/dev/null; then
+    printf 'stale=true\n'
+    printf 'reason=Latest approval commit %s is not available in fetched repository state\n' "$approval_sha"
+    return 0
+  fi
+
+  if ! run_git "$repository_path" rev-parse --verify --quiet "$head_sha^{commit}" >/dev/null; then
+    echo "head commit ${head_sha} is not available in fetched repository state" >&2
+    return 1
+  fi
+
+  if ! run_git "$repository_path" merge-base --is-ancestor "$approval_sha" "$head_sha"; then
+    printf 'stale=true\n'
+    printf 'reason=Latest approval commit %s is not an ancestor of %s, indicating rewritten history after approval\n' "$approval_sha" "$head_sha"
+    return 0
+  fi
+
+  local merge_commit merge_commits merge_tree_output merge_tree_status conflict_files reason
+
+  if ! merge_commits="$(run_git "$repository_path" rev-list --merges "${approval_sha}..${head_sha}")"; then
+    echo "rev-list failed for ${approval_sha}..${head_sha}" >&2
+    return 1
+  fi
+
+  while read -r merge_commit; do
+    [[ -n "$merge_commit" ]] || continue
+
+    if merge_tree_output="$(run_git "$repository_path" merge-tree "${merge_commit}^1" "${merge_commit}^2" 2>&1)"; then
+      merge_tree_status=0
+    else
+      merge_tree_status=$?
+    fi
+
+    if [[ $merge_tree_status -ne 0 && "$merge_tree_output" != *"CONFLICT"* ]]; then
+      echo "merge-tree failed for ${merge_commit}: ${merge_tree_output}" >&2
+      return "$merge_tree_status"
+    fi
+
+    if [[ "$merge_tree_output" != *"CONFLICT"* ]]; then
+      continue
+    fi
+
+    conflict_files="$(
+      {
+        printf '%s\n' "$merge_tree_output" | awk '/^CONFLICT / { sub(/^.* Merge conflict in /, ""); print }'
+        printf '%s\n' "$merge_tree_output" | awk '$3 ~ /^[123]$/ { print $4 }'
+      } | awk 'NF > 0' | sort -u | paste -sd, -
+    )"
+
+    reason="Manual conflict resolution detected after approval in merge commit ${merge_commit}"
+    if [[ -n "$conflict_files" ]]; then
+      reason="${reason} for files: ${conflict_files}"
+    fi
+
+    printf 'stale=true\n'
+    printf 'merge_commit=%s\n' "$merge_commit"
+    printf 'conflict_files=%s\n' "$conflict_files"
+    printf 'reason=%s\n' "$reason"
+    return 0
+  done <<< "$merge_commits"
+
+  printf 'stale=false\nreason=\n'
+}
+
+main() {
+  local approval_sha=""
+  local head_sha=""
+  local repository_path="."
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --approval-sha)
+        approval_sha="$2"
+        shift 2
+        ;;
+      --head-sha)
+        head_sha="$2"
+        shift 2
+        ;;
+      --repository-path)
+        repository_path="$2"
+        shift 2
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  run_check_manual_merge_resolutions "$repository_path" "$approval_sha" "$head_sha"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/actions/dismiss-stale-approvals/decide-stale-approvals.sh
+++ b/.github/actions/dismiss-stale-approvals/decide-stale-approvals.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_decide_stale_approvals() {
+  local approval_outcome="$1"
+  local merge_tree_outcome="$2"
+  local merge_tree_stale="$3"
+  local merge_tree_reason="$4"
+  local range_diff_outcome="$5"
+  local range_diff_stale="$6"
+  local no_prev_shas="$7"
+  local workflow_run_url="$8"
+
+  local stale="false"
+  local reason=""
+
+  if [[ "$approval_outcome" != "success" ]]; then
+    stale="true"
+    reason="Failed to read latest approval SHA; see action logs at $workflow_run_url"
+  elif [[ "$merge_tree_outcome" != "success" ]]; then
+    stale="true"
+    reason="Failed to check whether merge commits after approval required manual conflict resolution; see action logs at $workflow_run_url"
+  elif [[ "$merge_tree_stale" == "true" ]]; then
+    stale="true"
+    reason="$merge_tree_reason"
+  elif [[ "$range_diff_outcome" != "success" ]]; then
+    stale="true"
+    reason="Failed to check if diff has changed; see action logs at $workflow_run_url"
+  elif [[ "$no_prev_shas" == "1" ]]; then
+    stale="true"
+    reason="Could not find data on the previous version of this PR; see action logs at $workflow_run_url"
+  elif [[ "$range_diff_stale" == "true" ]]; then
+    stale="true"
+    reason="See the output of \`git range-diff\` at $workflow_run_url"
+  fi
+
+  printf 'stale=%s\n' "$stale"
+  printf 'reason=%s\n' "$reason"
+}
+
+main() {
+  local approval_outcome=""
+  local merge_tree_outcome=""
+  local merge_tree_stale=""
+  local merge_tree_reason=""
+  local range_diff_outcome=""
+  local range_diff_stale=""
+  local no_prev_shas="0"
+  local workflow_run_url=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --approval-outcome)
+        approval_outcome="$2"
+        shift 2
+        ;;
+      --merge-tree-outcome)
+        merge_tree_outcome="$2"
+        shift 2
+        ;;
+      --merge-tree-stale)
+        merge_tree_stale="$2"
+        shift 2
+        ;;
+      --merge-tree-reason)
+        merge_tree_reason="$2"
+        shift 2
+        ;;
+      --range-diff-outcome)
+        range_diff_outcome="$2"
+        shift 2
+        ;;
+      --range-diff-stale)
+        range_diff_stale="$2"
+        shift 2
+        ;;
+      --no-prev-shas)
+        no_prev_shas="$2"
+        shift 2
+        ;;
+      --workflow-run-url)
+        workflow_run_url="$2"
+        shift 2
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  run_decide_stale_approvals \
+    "$approval_outcome" \
+    "$merge_tree_outcome" \
+    "$merge_tree_stale" \
+    "$merge_tree_reason" \
+    "$range_diff_outcome" \
+    "$range_diff_stale" \
+    "$no_prev_shas" \
+    "$workflow_run_url"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/actions/dismiss-stale-approvals/dismiss-reviews.sh
+++ b/.github/actions/dismiss-stale-approvals/dismiss-reviews.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_dismiss_reviews() {
+  local repository="$1"
+  local pr_number="$2"
+  local reason="$3"
+  local dry_run="$4"
+  local review_ids review_id
+
+  review_ids="$(gh api --paginate "repos/${repository}/pulls/${pr_number}/reviews" \
+    --jq '.[] | select(.state=="APPROVED") | .id')"
+
+  if [[ -z "$review_ids" ]]; then
+    echo "No approvals to dismiss"
+    return 0
+  fi
+
+  if [[ "$dry_run" =~ ^(true|1|yes)$ ]]; then
+    gh pr comment "$pr_number" --repo "$repository" --body "$reason" >/dev/null
+    echo "[dry-run] Commented on PR ${pr_number} instead of dismissing approvals"
+    return 0
+  fi
+
+  while read -r review_id; do
+    [[ -n "$review_id" ]] || continue
+
+    gh api \
+      --method PUT \
+      "repos/${repository}/pulls/${pr_number}/reviews/${review_id}/dismissals" \
+      -f message="$reason" >/dev/null
+  done <<< "$review_ids"
+}
+
+main() {
+  local repository=""
+  local pr_number=""
+  local reason=""
+  local dry_run="false"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repository)
+        repository="$2"
+        shift 2
+        ;;
+      --pr-number)
+        pr_number="$2"
+        shift 2
+        ;;
+      --reason)
+        reason="$2"
+        shift 2
+        ;;
+      --dry-run)
+        dry_run="$2"
+        shift 2
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  run_dismiss_reviews "$repository" "$pr_number" "$reason" "$dry_run"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/actions/dismiss-stale-approvals/latest-approval-sha.sh
+++ b/.github/actions/dismiss-stale-approvals/latest-approval-sha.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+collect_paginated_reviews() {
+  jq -sc 'add'
+}
+
+find_latest_approval_sha() {
+  local reviews_json="$1"
+
+  jq -r '[.[] | select(.state=="APPROVED" and (.commit_id // empty != empty) and (.submitted_at // empty != empty))] | (if length > 0 then max_by(.submitted_at).commit_id else empty end)' <<<"$reviews_json"
+}
+
+main() {
+  local repository="$1"
+  local pr_number="$2"
+  local reviews_json
+
+  reviews_json="$(gh api --paginate "/repos/${repository}/pulls/${pr_number}/reviews" | collect_paginated_reviews)"
+  find_latest_approval_sha "$reviews_json"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/actions/dismiss-stale-approvals/latest-artifact.sh
+++ b/.github/actions/dismiss-stale-approvals/latest-artifact.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echoerr() { echo "$@" 1>&2; }
+
+collect_paginated_array() {
+  local array_key="$1"
+  jq -sc --arg array_key "$array_key" 'map(.[ $array_key ] // []) | add'
+}
+
+gh_api_collect() {
+  local endpoint="$1"
+  local array_key="$2"
+  gh api --paginate "/${endpoint}" | collect_paginated_array "$array_key"
+}
+
+find_latest_workflow_id() {
+  local workflows_json="$1"
+  local workflow_name="$2"
+  jq \
+    --arg workflow_name "$workflow_name" \
+    '[.[] | select(.name==$workflow_name)] | (if length>0 then (max_by(.updated_at).id) else null end)' <<<"${workflows_json}"
+}
+
+find_latest_workflow_run_id() {
+  local runs_json="$1"
+  local pr_number="$2"
+  jq \
+    --argjson pr_number "${pr_number}" \
+    '([.[] | select(.pull_requests | any(.number == $pr_number))] | max_by(.run_number)) | .id' <<<"${runs_json}"
+}
+
+find_latest_artifact_id() {
+  local artifacts_json="$1"
+  local artifact_name="$2"
+  jq \
+    --arg artifact_name "$artifact_name" \
+    '[.[] | select(.name==$artifact_name)] | (if length>0 then (max_by(.created_at // .updated_at // "").id) else null end)' <<<"${artifacts_json}"
+}
+
+main() {
+  local repository="$1"
+  local pr_number="$2"
+  local branch_name="$3"
+  local workflow_name="$4"
+  local artifact_name="$5"
+
+  local workflows latest_workflow_id runs latest_workflow_run_id artifacts latest_artifact_id
+
+  workflows="$(gh_api_collect "repos/${repository}/actions/workflows" "workflows")"
+  latest_workflow_id="$(find_latest_workflow_id "${workflows}" "${workflow_name}" || echo "ERROR")"
+
+  if [[ "${latest_workflow_id}" == "ERROR" ]]; then
+    echoerr "Failed to parse workflows with jq"
+    echoerr "${workflows}"
+    exit 0
+  fi
+
+  if [[ -z "${latest_workflow_id}" || "${latest_workflow_id}" == "null" ]]; then
+    echoerr "No workflow found with name ${workflow_name}"
+    exit 0
+  fi
+  echoerr "Latest workflow ID: ${latest_workflow_id}"
+
+  runs="$(gh_api_collect "repos/${repository}/actions/workflows/${latest_workflow_id}/runs?status=success&branch=${branch_name}" "workflow_runs")"
+  latest_workflow_run_id="$(find_latest_workflow_run_id "${runs}" "${pr_number}" || echo "ERROR")"
+
+  if [[ "${latest_workflow_run_id}" == "ERROR" ]]; then
+    echoerr "Failed to parse workflow runs with jq"
+    echoerr "${runs}"
+    exit 0
+  fi
+
+  if [[ -z "${latest_workflow_run_id}" || "${latest_workflow_run_id}" == "null" ]]; then
+    echoerr "No successful workflow run found for PR ${pr_number} on branch ${branch_name}"
+    exit 0
+  fi
+  echoerr "Latest workflow run ID: ${latest_workflow_run_id}"
+
+  artifacts="$(gh_api_collect "repos/${repository}/actions/runs/${latest_workflow_run_id}/artifacts" "artifacts")"
+  latest_artifact_id="$(find_latest_artifact_id "${artifacts}" "${artifact_name}" || echo "ERROR")"
+
+  if [[ "${latest_artifact_id}" == "ERROR" ]]; then
+    echoerr "Failed to parse artifacts with jq"
+    echoerr "${artifacts}"
+    exit 0
+  fi
+
+  if [[ -z "${latest_artifact_id}" || "${latest_artifact_id}" == "null" ]]; then
+    echoerr "No artifacts found for workflow run ${latest_workflow_run_id}"
+    exit 0
+  fi
+  echoerr "Latest artifact ID: ${latest_artifact_id}"
+
+  gh api "/repos/${repository}/actions/artifacts/${latest_artifact_id}/zip" > "${artifact_name}.zip"
+  unzip -q "${artifact_name}.zip"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/actions/dismiss-stale-approvals/range-diff-stale.sh
+++ b/.github/actions/dismiss-stale-approvals/range-diff-stale.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_range_diff_stale() {
+  local range_diff
+  range_diff="$(cat)"
+
+  if printf '%s\n' "$range_diff" | awk 'NF >= 3 { print $3 }' | grep -vq '^=$'; then
+    printf 'stale=true\n'
+  else
+    printf 'stale=false\n'
+  fi
+}
+
+main() {
+  run_range_diff_stale
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/actions/dismiss-stale-approvals/self-test.sh
+++ b/.github/actions/dismiss-stale-approvals/self-test.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ACTION_DIR="$REPO_ROOT/.github/actions/dismiss-stale-approvals"
+ACTION_YML="$ACTION_DIR/action.yml"
+
+# shellcheck disable=SC1091
+source "$ACTION_DIR/latest-artifact.sh"
+# shellcheck disable=SC1091
+source "$ACTION_DIR/latest-approval-sha.sh"
+# shellcheck disable=SC1091
+source "$ACTION_DIR/decide-stale-approvals.sh"
+# shellcheck disable=SC1091
+source "$ACTION_DIR/check-manual-merge-resolutions.sh"
+# shellcheck disable=SC1091
+source "$ACTION_DIR/range-diff-stale.sh"
+# shellcheck disable=SC1091
+source "$ACTION_DIR/dismiss-reviews.sh"
+
+TEMP_PATHS=()
+
+register_temp_path() {
+  TEMP_PATHS+=("$1")
+}
+
+cleanup_temp_paths() {
+  local temp_path
+
+  for temp_path in "${TEMP_PATHS[@]}"; do
+    [[ -e "$temp_path" ]] && rm -rf "$temp_path"
+  done
+}
+
+trap cleanup_temp_paths EXIT
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+
+  [[ "$haystack" == *"$needle"* ]] || fail "Expected output to contain: $needle"$'\n'"Actual output:"$'\n'"$haystack"
+}
+
+create_repo() {
+  local repo_path="$1"
+
+  git init -q "$repo_path"
+  git -C "$repo_path" config user.name "Codex"
+  git -C "$repo_path" config user.email "codex@example.com"
+}
+
+extract_step_block() {
+  local step_name="$1"
+
+  awk -v step_name="$step_name" '
+    $0 ~ "^[[:space:]]*-[[:space:]]name:[[:space:]]*" step_name "$" {
+      if (seen_step) {
+        exit
+      }
+      capture=1
+    }
+    capture {
+      if ($0 ~ "^[[:space:]]*-[[:space:]]name:[[:space:]]*" && $0 !~ step_name && seen_step) {
+        exit
+      }
+      print
+      seen_step=1
+    }
+  ' "$ACTION_YML"
+}
+
+test_collect_paginated_array() {
+  local output
+  output="$(
+    printf '%s\n%s\n' \
+      '{"workflow_runs":[{"id":1},{"id":2}]}' \
+      '{"workflow_runs":[{"id":3}]}' |
+      collect_paginated_array "workflow_runs"
+  )"
+
+  [[ "$output" == '[{"id":1},{"id":2},{"id":3}]' ]] ||
+    fail "Expected flattened paginated array, got: $output"
+
+  local workflow_id run_id artifact_id
+  workflow_id="$(find_latest_workflow_id '[{"id":11,"name":"Other","updated_at":"2026-03-24T00:00:00Z"},{"id":22,"name":"Dismiss stale pull request approvals","updated_at":"2026-03-25T00:00:00Z"}]' 'Dismiss stale pull request approvals')"
+  run_id="$(find_latest_workflow_run_id '[{"id":31,"run_number":8,"pull_requests":[{"number":8577}]},{"id":32,"run_number":9,"pull_requests":[{"number":8577}]},{"id":33,"run_number":10,"pull_requests":[{"number":9999}]}]' '8577')"
+  artifact_id="$(find_latest_artifact_id '[{"id":41,"name":"other-artifact"},{"id":42,"name":"dismiss-stale-approvals-shas"}]' 'dismiss-stale-approvals-shas')"
+
+  [[ "$workflow_id" == "22" ]] || fail "Expected latest workflow id 22, got: $workflow_id"
+  [[ "$run_id" == "32" ]] || fail "Expected latest workflow run id 32, got: $run_id"
+  [[ "$artifact_id" == "42" ]] || fail "Expected latest artifact id 42, got: $artifact_id"
+
+  artifact_id="$(find_latest_artifact_id '[{"id":51,"name":"dismiss-stale-approvals-shas","created_at":"2026-03-24T00:00:00Z"},{"id":52,"name":"dismiss-stale-approvals-shas","created_at":"2026-03-25T00:00:00Z"}]' 'dismiss-stale-approvals-shas')"
+  [[ "$artifact_id" == "52" ]] || fail "Expected newest duplicate artifact id 52, got: $artifact_id"
+
+  artifact_id="$(find_latest_artifact_id '[{"id":61,"name":"other-artifact","created_at":"2026-03-25T00:00:00Z"}]' 'dismiss-stale-approvals-shas')"
+  [[ "$artifact_id" == "null" ]] || fail "Expected null when no artifact matches, got: $artifact_id"
+}
+
+test_collect_paginated_reviews() {
+  local reviews_json latest_approval_sha
+  reviews_json="$(
+    printf '%s\n%s\n' \
+      '[{"state":"APPROVED","commit_id":"sha-newest","submitted_at":"2026-03-25T12:00:00Z"},{"state":"COMMENTED","commit_id":"ignore-comment","submitted_at":"2026-03-25T13:00:00Z"}]' \
+      '[{"state":"APPROVED","commit_id":"sha-oldest","submitted_at":"2026-03-24T12:00:00Z"},{"state":"CHANGES_REQUESTED","commit_id":"ignore-change-request","submitted_at":"2026-03-25T14:00:00Z"}]' |
+      collect_paginated_reviews
+  )"
+
+  [[ "$reviews_json" == '[{"state":"APPROVED","commit_id":"sha-newest","submitted_at":"2026-03-25T12:00:00Z"},{"state":"COMMENTED","commit_id":"ignore-comment","submitted_at":"2026-03-25T13:00:00Z"},{"state":"APPROVED","commit_id":"sha-oldest","submitted_at":"2026-03-24T12:00:00Z"},{"state":"CHANGES_REQUESTED","commit_id":"ignore-change-request","submitted_at":"2026-03-25T14:00:00Z"}]' ]] ||
+    fail "Expected flattened paginated reviews array, got: $reviews_json"
+
+  latest_approval_sha="$(find_latest_approval_sha "$reviews_json")"
+  [[ "$latest_approval_sha" == "sha-newest" ]] ||
+    fail "Expected latest approval SHA sha-newest, got: $latest_approval_sha"
+
+  latest_approval_sha="$(find_latest_approval_sha '[{"state":"COMMENTED","commit_id":"ignore","submitted_at":"2026-03-25T12:00:00Z"},{"state":"CHANGES_REQUESTED","commit_id":"ignore-change-request","submitted_at":"2026-03-25T13:00:00Z"}]')"
+  [[ -z "$latest_approval_sha" ]] ||
+    fail "Expected no approval SHA when there are no approved reviews, got: $latest_approval_sha"
+}
+
+test_empty_range_diff_is_not_stale() {
+  local output
+
+  output="$(printf '' | run_range_diff_stale)"
+  [[ "$output" == "stale=false" ]] ||
+    fail "Expected an empty range-diff output to keep stale=false, got: $output"
+
+  output="$(printf '%s\n' '1: abcdef = 1: abcdef' | run_range_diff_stale)"
+  [[ "$output" == "stale=false" ]] ||
+    fail "Expected an unchanged range-diff entry to keep stale=false, got: $output"
+
+  output="$(printf '%s\n' '1: abcdef < 1: fedcba' | run_range_diff_stale)"
+  [[ "$output" == "stale=true" ]] ||
+    fail "Expected a changed range-diff entry to set stale=true, got: $output"
+}
+
+test_no_approval_is_not_stale() {
+  local repo_path output
+  repo_path="$(mktemp -d)"
+  register_temp_path "$repo_path"
+
+  create_repo "$repo_path"
+
+  printf 'base\n' >"$repo_path/file.txt"
+  git -C "$repo_path" add file.txt
+  git -C "$repo_path" commit -qm "base"
+
+  output="$(run_check_manual_merge_resolutions "$repo_path" "" "$(git -C "$repo_path" rev-parse HEAD)")"
+
+  assert_contains "$output" "stale=false"
+}
+
+test_decision_marks_approval_lookup_failure_stale() {
+  local output
+  output="$(run_decide_stale_approvals "failure" "success" "false" "" "success" "false" "0" "https://example.test/run")"
+
+  assert_contains "$output" "stale=true"
+  assert_contains "$output" "Failed to read latest approval SHA"
+}
+
+test_decision_keeps_successful_no_approval_path_safe() {
+  local output
+  output="$(run_decide_stale_approvals "success" "success" "false" "" "success" "false" "0" "https://example.test/run")"
+
+  [[ "$output" == $'stale=false\nreason=' ]] ||
+    fail "Expected a successful no-approval decision to stay non-stale, got:"$'\n'"$output"
+}
+
+test_rewritten_history_is_stale() {
+  local repo_path
+  repo_path="$(mktemp -d)"
+  register_temp_path "$repo_path"
+
+  create_repo "$repo_path"
+
+  printf 'base\n' >"$repo_path/file.txt"
+  git -C "$repo_path" add file.txt
+  git -C "$repo_path" commit -qm "base"
+
+  printf 'approved\n' >"$repo_path/file.txt"
+  git -C "$repo_path" commit -qam "approved"
+  local approval_sha
+  approval_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  git -C "$repo_path" reset --hard HEAD~1 >/dev/null
+
+  printf 'rewritten\n' >"$repo_path/file.txt"
+  git -C "$repo_path" commit -qam "rewritten"
+  local head_sha
+  head_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  local output
+  output="$(run_check_manual_merge_resolutions "$repo_path" "$approval_sha" "$head_sha")"
+
+  assert_contains "$output" "stale=true"
+  assert_contains "$output" "rewritten history"
+}
+
+test_rev_list_failure_returns_nonzero() {
+  local repo_path output status
+  repo_path="$(mktemp -d)"
+  register_temp_path "$repo_path"
+
+  create_repo "$repo_path"
+
+  printf 'base\n' >"$repo_path/file.txt"
+  git -C "$repo_path" add file.txt
+  git -C "$repo_path" commit -qm "base"
+
+  printf 'approved\n' >"$repo_path/file.txt"
+  git -C "$repo_path" commit -qam "approved"
+  local approval_sha
+  approval_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  printf 'head\n' >"$repo_path/file.txt"
+  git -C "$repo_path" commit -qam "head"
+  local head_sha
+  head_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  run_git() {
+    local repository_path="$1"
+    shift
+
+    if [[ "$1" == "rev-list" ]]; then
+      echo "forced rev-list failure" >&2
+      return 42
+    fi
+
+    git -C "$repository_path" "$@"
+  }
+
+  if output="$(run_check_manual_merge_resolutions "$repo_path" "$approval_sha" "$head_sha" 2>/dev/null)"; then
+    status=0
+  else
+    status=$?
+  fi
+
+  # shellcheck disable=SC1091
+  source "$ACTION_DIR/check-manual-merge-resolutions.sh"
+
+  [[ $status -ne 0 ]] || fail "Expected rev-list failure to propagate as non-zero, got output:"$'\n'"$output"
+}
+
+test_missing_approval_commit_is_stale() {
+  local repo_path bare_repo_path shallow_repo_path
+  repo_path="$(mktemp -d)"
+  bare_repo_path="$(mktemp -d)"
+  shallow_repo_path="$(mktemp -d)"
+  register_temp_path "$repo_path"
+  register_temp_path "$bare_repo_path"
+  register_temp_path "$shallow_repo_path"
+
+  create_repo "$repo_path"
+
+  printf '0\n' >"$repo_path/file.txt"
+  git -C "$repo_path" add file.txt
+  git -C "$repo_path" commit -qm "base"
+
+  printf '1\n' >"$repo_path/file.txt"
+  git -C "$repo_path" commit -qam "approved"
+  local approval_sha
+  approval_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  printf '2\n' >"$repo_path/file.txt"
+  git -C "$repo_path" commit -qam "head"
+  local head_sha
+  head_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  git clone --bare "$repo_path" "$bare_repo_path/repo.git" >/dev/null 2>&1
+  git init -q --bare "$shallow_repo_path/repo.git"
+  git -C "$shallow_repo_path/repo.git" remote add origin "$bare_repo_path/repo.git"
+  git -C "$shallow_repo_path/repo.git" fetch -q origin --depth=1 "$head_sha"
+
+  local output
+  output="$(run_check_manual_merge_resolutions "$shallow_repo_path/repo.git" "$approval_sha" "$head_sha")"
+
+  assert_contains "$output" "stale=true"
+  assert_contains "$output" "not available in fetched repository state"
+}
+
+test_bare_repo_conflict_merge_is_stale() {
+  local repo_path bare_repo_path
+  repo_path="$(mktemp -d)"
+  bare_repo_path="$(mktemp -d)"
+  register_temp_path "$repo_path"
+  register_temp_path "$bare_repo_path"
+
+  create_repo "$repo_path"
+
+  printf 'base\n' >"$repo_path/file.txt"
+  git -C "$repo_path" add file.txt
+  git -C "$repo_path" commit -qm "base"
+
+  local trunk_branch
+  trunk_branch="$(git -C "$repo_path" branch --show-current)"
+
+  git -C "$repo_path" checkout -qb feature
+  printf 'feature\n' >"$repo_path/file.txt"
+  git -C "$repo_path" commit -qam "feature change"
+  local approval_sha
+  approval_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  git -C "$repo_path" checkout -q "$trunk_branch"
+  printf 'main\n' >"$repo_path/file.txt"
+  git -C "$repo_path" commit -qam "main change"
+
+  git -C "$repo_path" checkout -q feature
+  if git -C "$repo_path" merge "$trunk_branch" >/dev/null 2>&1; then
+    fail "Expected merge conflict"
+  fi
+
+  printf 'resolved\n' >"$repo_path/file.txt"
+  git -C "$repo_path" add file.txt
+  git -C "$repo_path" commit -qm "resolve conflict"
+  local head_sha
+  head_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  git clone --bare "$repo_path" "$bare_repo_path/repo.git" >/dev/null 2>&1
+
+  local output
+  output="$(run_check_manual_merge_resolutions "$bare_repo_path/repo.git" "$approval_sha" "$head_sha")"
+
+  assert_contains "$output" "stale=true"
+  assert_contains "$output" "file.txt"
+}
+
+test_action_wires_checker_to_fetched_repo() {
+  if ! grep -Fq -- "--repository-path \"\$FETCHED_REPOSITORY_PATH\"" "$ACTION_YML"; then
+    fail 'Expected action.yml to pass the fetched repository path into check-manual-merge-resolutions.sh'
+  fi
+}
+
+test_action_uses_shared_range_diff_helper() {
+  if ! grep -Fq -- 'range-diff-stale.sh' "$ACTION_YML"; then
+    fail 'Expected action.yml to delegate range-diff parsing to range-diff-stale.sh'
+  fi
+}
+
+test_action_reads_latest_approval_sha_via_helper() {
+  if ! grep -Fq -- 'latest-approval-sha.sh' "$ACTION_YML"; then
+    fail 'Expected action.yml to read the latest approval SHA via latest-approval-sha.sh'
+  fi
+
+  if ! grep -Fq -- "\"\$APPROVAL_SHA\"" "$ACTION_YML"; then
+    fail 'Expected action.yml to fetch or pass the latest approval SHA explicitly'
+  fi
+}
+
+test_hyphenated_helpers_exist_and_are_executable() {
+  local helper_path
+
+  for helper_path in \
+    "$ACTION_DIR/decide-stale-approvals.sh" \
+    "$ACTION_DIR/check-manual-merge-resolutions.sh" \
+    "$ACTION_DIR/dismiss-reviews.sh" \
+    "$ACTION_DIR/latest-approval-sha.sh" \
+    "$ACTION_DIR/latest-artifact.sh" \
+    "$ACTION_DIR/range-diff-stale.sh"; do
+    [[ -x "$helper_path" ]] || fail "Expected helper to exist and be executable: $helper_path"
+  done
+}
+
+test_action_continues_after_approval_lookup_failure() {
+  local approval_block
+  approval_block="$(extract_step_block "Read latest approval SHA")"
+
+  [[ "$approval_block" == *"continue-on-error: true"* ]] ||
+    fail "Expected the approval lookup step to continue on error"$'\n'"$approval_block"
+}
+
+test_action_run_blocks_do_not_inline_github_context() {
+  local offending_lines
+  offending_lines="$(
+    awk '
+      /run: \|/ { in_run=1; next }
+      in_run && /^[[:space:]]*-[[:space:]]name:/ { in_run=0 }
+      in_run && /\$\{\{[[:space:]]*github\./ { print NR ":" $0 }
+    ' "$ACTION_YML"
+  )"
+
+  if [[ -n "$offending_lines" ]]; then
+    fail "Expected run blocks to avoid direct github.* interpolation"$'\n'"$offending_lines"
+  fi
+}
+
+test_action_uses_github_env_shas_without_redeclaring_them() {
+  local range_diff_block merge_tree_block
+  range_diff_block="$(extract_step_block "Check if diff has changed")"
+  merge_tree_block="$(extract_step_block "Check for manual merge resolutions after approval")"
+
+  if grep -Eq '^[[:space:]]+BASE_SHA:' <<<"$range_diff_block"; then
+    fail "Expected the range-diff step to read BASE_SHA from GITHUB_ENV"$'\n'"$range_diff_block"
+  fi
+
+  if grep -Eq '^[[:space:]]+HEAD_SHA:' <<<"$range_diff_block"; then
+    fail "Expected the range-diff step to read HEAD_SHA from GITHUB_ENV"$'\n'"$range_diff_block"
+  fi
+
+  if grep -Eq '^[[:space:]]+HEAD_SHA:' <<<"$merge_tree_block"; then
+    fail "Expected the merge-tree step to read HEAD_SHA from GITHUB_ENV"$'\n'"$merge_tree_block"
+  fi
+}
+
+main() {
+  test_collect_paginated_array
+  test_collect_paginated_reviews
+  test_empty_range_diff_is_not_stale
+  test_no_approval_is_not_stale
+  test_decision_marks_approval_lookup_failure_stale
+  test_decision_keeps_successful_no_approval_path_safe
+  test_rewritten_history_is_stale
+  test_rev_list_failure_returns_nonzero
+  test_missing_approval_commit_is_stale
+  test_bare_repo_conflict_merge_is_stale
+  test_action_uses_shared_range_diff_helper
+  test_action_wires_checker_to_fetched_repo
+  test_action_reads_latest_approval_sha_via_helper
+  test_hyphenated_helpers_exist_and_are_executable
+  test_action_continues_after_approval_lookup_failure
+  test_action_run_blocks_do_not_inline_github_context
+  test_action_uses_github_env_shas_without_redeclaring_them
+
+  echo "dismiss-stale-approvals self-test passed"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -7,12 +7,12 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
-name: Dependency review
+name: Dependencies
 
 on:
   pull_request:
     paths:
-      - ".github/workflows/dependency-review.yml"
+      - ".github/workflows/dependencies.yml"
   pull_request_target:
   merge_group:
   workflow_call:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,7 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
-name: Dependency Review
+name: Dependency review
 
 on:
   pull_request:
@@ -22,7 +22,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependency-review:
+  review:
+    name: Review
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -5,7 +5,7 @@
 #
 # TODO: Replace OIDC workaround with $/ syntax once available
 # see: https://github.com/orgs/community/discussions/26245#discussioncomment-15601440
-name: Dismiss stale pull request approvals
+name: Stale approvals
 
 on:
   pull_request:
@@ -27,7 +27,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  dismiss-stale-approvals:
+  dismiss:
+    name: Dismiss
     runs-on: ubuntu-24.04
     steps:
       - name: Resolve reusable workflow ref

--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -19,6 +19,10 @@ on:
 permissions:
   actions: read
   contents: read
+  # Required to extract job_workflow_ref from the OIDC token, which contains
+  # the ref this reusable workflow was called with. This is the only reliable
+  # way to resolve the correct checkout ref for the composite action.
+  # see: https://github.com/actions/toolkit/issues/1264
   id-token: write
   pull-requests: write
 

--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -18,8 +18,7 @@ jobs:
   dismiss_stale_approvals:
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout action from trusted ref
-        if: github.event_name != 'pull_request'
+      - name: Checkout action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: hashintel/.github
@@ -27,15 +26,12 @@ jobs:
           sparse-checkout: |
             .github/actions/dismiss-stale-approvals
 
-      - name: Checkout pull request revision
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Run self-test
         if: github.event_name == 'pull_request'
         run: .github/actions/dismiss-stale-approvals/self-test.sh
 
       - name: Dismiss stale pull request approvals
+        if: github.event_name != 'merge_group'
         uses: ./.github/actions/dismiss-stale-approvals
         with:
           dry-run: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -55,7 +55,7 @@ jobs:
         run: .github/actions/dismiss-stale-approvals/self-test.sh
 
       - name: Dismiss stale pull request approvals
-        if: github.event_name != 'merge_group'
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         uses: ./.github/actions/dismiss-stale-approvals
         with:
           dry-run: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -1,3 +1,10 @@
+# Dismiss stale pull request approvals
+#
+# Reusable workflow that dismisses PR approvals when the diff changes.
+# Uses OIDC token to resolve the correct checkout ref for the action.
+#
+# TODO: Replace OIDC workaround with $/ syntax once available
+# see: https://github.com/orgs/community/discussions/26245#discussioncomment-15601440
 name: Dismiss stale pull request approvals
 
 on:
@@ -12,21 +19,29 @@ on:
 permissions:
   actions: read
   contents: read
+  id-token: write
   pull-requests: write
 
 jobs:
   dismiss_stale_approvals:
     runs-on: ubuntu-24.04
     steps:
-      - name: Resolve checkout ref
-        id: ref
-        run: echo "sha=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+      - name: Resolve reusable workflow ref
+        id: workflow-ref
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const token = await core.getIDToken();
+            const [, payload] = token.split('.');
+            const { job_workflow_ref } = JSON.parse(Buffer.from(payload, 'base64url'));
+            const ref = job_workflow_ref.split('@')[1];
+            core.setOutput('ref', ref);
 
       - name: Checkout action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: hashintel/.github
-          ref: ${{ steps.ref.outputs.sha }}
+          ref: ${{ steps.workflow-ref.outputs.ref }}
           sparse-checkout: |
             .github/actions/dismiss-stale-approvals
 

--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -28,7 +28,6 @@ permissions:
 
 jobs:
   dismiss-stale-approvals:
-    name: Dismiss stale approvals
     runs-on: ubuntu-24.04
     steps:
       - name: Resolve reusable workflow ref

--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -1,0 +1,42 @@
+name: Dismiss stale pull request approvals
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/dismiss-stale-approvals.yml"
+      - ".github/actions/dismiss-stale-approvals/**"
+  pull_request_target:
+  merge_group:
+  workflow_call:
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  dismiss_stale_approvals:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout action from trusted ref
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: hashintel/.github
+          ref: ${{ github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/dismiss-stale-approvals
+
+      - name: Checkout pull request revision
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run self-test
+        if: github.event_name == 'pull_request'
+        run: .github/actions/dismiss-stale-approvals/self-test.sh
+
+      - name: Dismiss stale pull request approvals
+        uses: ./.github/actions/dismiss-stale-approvals
+        with:
+          dry-run: ${{ github.event_name == 'pull_request' }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -27,7 +27,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  dismiss_stale_approvals:
+  dismiss-stale-approvals:
+    name: Dismiss stale approvals
     runs-on: ubuntu-24.04
     steps:
       - name: Resolve reusable workflow ref

--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -18,11 +18,15 @@ jobs:
   dismiss_stale_approvals:
     runs-on: ubuntu-24.04
     steps:
+      - name: Resolve checkout ref
+        id: ref
+        run: echo "sha=${GITHUB_WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: hashintel/.github
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.ref.outputs.sha }}
           sparse-checkout: |
             .github/actions/dismiss-stale-approvals
 

--- a/.github/workflows/todo-comments.yml
+++ b/.github/workflows/todo-comments.yml
@@ -1,0 +1,114 @@
+# Check TODO Linear Tickets
+#
+# Searches for TODO comments in the codebase that reference Linear ticket IDs
+# found in the PR title. Fails if any are found, as they should be resolved
+# before the associated ticket is marked as done.
+name: Todo Comments
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/todo-comments.yml"
+  pull_request_target:
+  merge_group:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan
+    runs-on: ubuntu-24.04
+    if: github.event_name != 'merge_group'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Extract ticket IDs from PR title
+        id: extract-tickets
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR Title: $PR_TITLE"
+
+          PREFIX=$(echo "$PR_TITLE" | cut -d':' -f1)
+
+          TICKETS=$(echo "$PREFIX" | grep -oiE '[A-Z]+-[0-9]+' | tr '[:lower:]' '[:upper:]' | sort -u | tr '\n' ' ')
+
+          if [[ -z "$TICKETS" ]]; then
+            echo "No ticket IDs found in PR title"
+            echo "tickets=" >> "$GITHUB_OUTPUT"
+            echo "has_tickets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found ticket IDs: $TICKETS"
+            echo "tickets=$TICKETS" >> "$GITHUB_OUTPUT"
+            echo "has_tickets=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Search for TODO comments with ticket IDs
+        if: steps.extract-tickets.outputs.has_tickets == 'true'
+        env:
+          TICKETS: ${{ steps.extract-tickets.outputs.tickets }}
+        run: |
+          echo "Searching for TODO comments containing ticket IDs: $TICKETS"
+
+          FOUND_TODOS=""
+          EXIT_CODE=0
+
+          for TICKET in $TICKETS; do
+            echo ""
+            echo "=========================================="
+            echo "Searching for references to $TICKET..."
+            echo "=========================================="
+
+            SINGLE_LINE=$(rg -in "todo.*${TICKET}([^[:alnum:]-]|$)|${TICKET}([^[:alnum:]-]|$).*todo" .) || {
+              rc=$?
+              if [[ $rc -ne 1 ]]; then
+                echo "::error::ripgrep failed with exit code $rc"
+                exit $rc
+              fi
+            }
+
+            MULTILINE=$(rg -inU \
+              -e "todo[\s\S]{0,300}linear\.app/[^/]+/issue/${TICKET}([^[:alnum:]-]|$)" \
+              -e "linear\.app/[^/]+/issue/${TICKET}([^[:alnum:]-]|$)[\s\S]{0,300}todo" \
+              .) || {
+              rc=$?
+              if [[ $rc -ne 1 ]]; then
+                echo "::error::ripgrep failed with exit code $rc"
+                exit $rc
+              fi
+            }
+
+            MATCHES=$(echo -e "${SINGLE_LINE}\n${MULTILINE}" | grep -v '^$' | sort -u) || true
+
+            if [[ -n "$MATCHES" ]]; then
+              echo "::error::Found TODO comments or Linear URLs referencing $TICKET:"
+              echo "$MATCHES"
+              FOUND_TODOS="${FOUND_TODOS}### ${TICKET}"$'\n'"${MATCHES}"$'\n\n'
+              EXIT_CODE=1
+            else
+              echo "No TODO comments found for $TICKET"
+            fi
+          done
+
+          if [[ $EXIT_CODE -eq 1 ]]; then
+            echo ""
+            echo "::error::TODOs associated with tickets in this PR were found in the codebase."
+            echo "::error::Please resolve these TODOs before merging, as the associated ticket(s) will be marked as done."
+            echo ""
+            echo "## Found TODO comments" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The following TODO comments reference ticket IDs from this PR's title." >> "$GITHUB_STEP_SUMMARY"
+            echo "Please resolve these TODOs before merging, as the associated ticket(s) will be marked as done." >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "$FOUND_TODOS" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+          echo "No TODO comments found for any ticket IDs in the PR title"

--- a/.github/workflows/todo-comments.yml
+++ b/.github/workflows/todo-comments.yml
@@ -20,7 +20,7 @@ jobs:
   scan:
     name: Scan
     runs-on: ubuntu-24.04
-    if: github.event_name != 'merge_group'
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     steps:
       - name: Checkout PR head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/todo-comments.yml
+++ b/.github/workflows/todo-comments.yml
@@ -27,6 +27,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install ripgrep
+        run: |
+          if ! command -v rg &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y ripgrep
+          fi
+
       - name: Extract ticket IDs from PR title
         id: extract-tickets
         env:


### PR DESCRIPTION
## Summary
- Adds `dismiss-stale-approvals` composite action and reusable workflow (moved from `hash` repo)
- Adds `todo-comments` reusable workflow (scans for TODO comments referencing Linear tickets)
- Renames `dependency-review.yml` to `dependencies.yml` for consistent naming
- Uses OIDC token (`job_workflow_ref`) to resolve the correct checkout ref for the composite action — no input parameter needed, Renovate-compatible
- Applies `Preflight / <topic> / <action>` naming convention for clean check display in callers

### Check naming convention
Callers add a `preflight.yml` workflow that calls these reusable workflows:
- `Preflight / Stale approvals / Dismiss`
- `Preflight / Dependencies / Review`
- `Preflight / Todo comments / Scan`

### OIDC workaround
Reusable workflows can't determine their own ref (all `github.*` context refers to the caller). We extract `job_workflow_ref` from the OIDC token to get the correct SHA for checking out the composite action. This will be replaced by the `$/` syntax once available:
https://github.com/orgs/community/discussions/26245#discussioncomment-15601440