### PR TITLE
SRE-637: Fix false positive stale approval dismissal on base-branch-only updates

### DIFF
--- a/.github/actions/dismiss-stale-approvals/action.yml
+++ b/.github/actions/dismiss-stale-approvals/action.yml
@@ -105,11 +105,14 @@ runs:
           "$BASE_SHA" \
           "$HEAD_SHA"
 
-        prev_merge_base="$(git -C "$FETCHED_REPOSITORY_PATH" merge-base "$PREV_BASE_SHA" "$PREV_HEAD_SHA")"
-        merge_base="$(git -C "$FETCHED_REPOSITORY_PATH" merge-base "$BASE_SHA" "$HEAD_SHA")"
-        range_diff="$(git -C "$FETCHED_REPOSITORY_PATH" range-diff "$prev_merge_base..$PREV_HEAD_SHA" "$merge_base..$HEAD_SHA")"
-
-        printf '%s\n' "$range_diff" | "$ACTION_PATH/range-diff-stale.sh" >> "$GITHUB_OUTPUT"
+        # shellcheck source=range-diff-stale.sh
+        source "$ACTION_PATH/range-diff-stale.sh"
+        run_check_range_diff_stale \
+          --repository-path "$FETCHED_REPOSITORY_PATH" \
+          --prev-base-sha "$PREV_BASE_SHA" \
+          --prev-head-sha "$PREV_HEAD_SHA" \
+          --base-sha "$BASE_SHA" \
+          --head-sha "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
     - name: Read latest approval SHA
       id: approval

--- a/.github/actions/dismiss-stale-approvals/range-diff-stale.sh
+++ b/.github/actions/dismiss-stale-approvals/range-diff-stale.sh
@@ -12,6 +12,46 @@ run_range_diff_stale() {
   fi
 }
 
+# Runs the full range-diff staleness check for a repository.
+# Handles the case where HEAD hasn't changed (base-branch-only advance).
+#
+# Arguments:
+#   --repository-path  Path to a git repo (bare or non-bare)
+#   --prev-base-sha    Previous base branch SHA
+#   --prev-head-sha    Previous PR head SHA
+#   --base-sha         Current base branch SHA
+#   --head-sha         Current PR head SHA
+#   --fetch-depth      (optional) Depth for git fetch (only for remote repos)
+run_check_range_diff_stale() {
+  local repository_path="" prev_base_sha="" prev_head_sha="" base_sha="" head_sha=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --repository-path) repository_path="$2"; shift 2 ;;
+      --prev-base-sha)   prev_base_sha="$2"; shift 2 ;;
+      --prev-head-sha)   prev_head_sha="$2"; shift 2 ;;
+      --base-sha)        base_sha="$2"; shift 2 ;;
+      --head-sha)        head_sha="$2"; shift 2 ;;
+      *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  # If the PR branch head hasn't changed, the reviewed code hasn't changed.
+  # This prevents false positives when only the base branch advances
+  # (e.g., squash-merge of a stacked PR shifting the merge-base).
+  if [[ "$head_sha" == "$prev_head_sha" ]]; then
+    printf 'stale=false\n'
+    return
+  fi
+
+  local prev_merge_base merge_base range_diff
+  prev_merge_base="$(git -C "$repository_path" merge-base "$prev_base_sha" "$prev_head_sha")"
+  merge_base="$(git -C "$repository_path" merge-base "$base_sha" "$head_sha")"
+  range_diff="$(git -C "$repository_path" range-diff "$prev_merge_base..$prev_head_sha" "$merge_base..$head_sha")"
+
+  printf '%s\n' "$range_diff" | run_range_diff_stale
+}
+
 main() {
   run_range_diff_stale
 }

--- a/.github/actions/dismiss-stale-approvals/self-test.sh
+++ b/.github/actions/dismiss-stale-approvals/self-test.sh
@@ -388,6 +388,114 @@ test_action_run_blocks_do_not_inline_github_context() {
   fi
 }
 
+test_base_branch_advance_is_not_stale() {
+  local repo_path
+  repo_path="$(mktemp -d)"
+  register_temp_path "$repo_path"
+
+  create_repo "$repo_path"
+
+  # main: initial commit
+  printf 'base\n' >"$repo_path/file.txt"
+  git -C "$repo_path" add file.txt
+  git -C "$repo_path" commit -qm "initial base"
+  local trunk_branch
+  trunk_branch="$(git -C "$repo_path" branch --show-current)"
+
+  # featureA branch (stacked PR base)
+  git -C "$repo_path" checkout -qb featureA
+  printf 'featureA\n' >"$repo_path/a.txt"
+  git -C "$repo_path" add a.txt
+  git -C "$repo_path" commit -qm "featureA commit"
+  local feature_a_sha
+  feature_a_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  # featureB branch (stacked on featureA)
+  git -C "$repo_path" checkout -qb featureB
+  printf 'featureB\n' >"$repo_path/b.txt"
+  git -C "$repo_path" add b.txt
+  git -C "$repo_path" commit -qm "featureB commit"
+  local head_sha
+  head_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  # Previous state: featureB targets featureA
+  local prev_base_sha="$feature_a_sha"
+  local prev_head_sha="$head_sha"
+
+  # Squash-merge featureA into main
+  git -C "$repo_path" checkout -q "$trunk_branch"
+  git -C "$repo_path" merge --squash featureA -q
+  git -C "$repo_path" commit -qm "squash merge featureA"
+  local base_sha
+  base_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  # featureB HEAD unchanged, base changed (retargeted to main)
+  local prev_merge_base merge_base range_diff output
+  prev_merge_base="$(git -C "$repo_path" merge-base "$prev_base_sha" "$prev_head_sha")"
+  merge_base="$(git -C "$repo_path" merge-base "$base_sha" "$head_sha")"
+  range_diff="$(git -C "$repo_path" range-diff "$prev_merge_base..$prev_head_sha" "$merge_base..$head_sha")"
+
+  output="$(printf '%s\n' "$range_diff" | run_range_diff_stale)"
+
+  # range-diff reports stale because merge-base shifted, but HEAD is unchanged
+  # so the action should short-circuit before reaching range-diff
+  # Here we verify the range-diff parser DOES report stale (the bug)
+  [[ "$output" == "stale=true" ]] ||
+    fail "Expected range-diff parser to report stale=true for shifted merge-base (this is the known false positive), got: $output"
+}
+
+test_base_branch_advance_e2e_is_not_stale() {
+  local repo_path
+  repo_path="$(mktemp -d)"
+  register_temp_path "$repo_path"
+
+  create_repo "$repo_path"
+
+  # main: initial commit
+  printf 'base\n' >"$repo_path/file.txt"
+  git -C "$repo_path" add file.txt
+  git -C "$repo_path" commit -qm "initial base"
+  local trunk_branch
+  trunk_branch="$(git -C "$repo_path" branch --show-current)"
+
+  # featureA branch
+  git -C "$repo_path" checkout -qb featureA
+  printf 'featureA\n' >"$repo_path/a.txt"
+  git -C "$repo_path" add a.txt
+  git -C "$repo_path" commit -qm "featureA commit"
+  local feature_a_sha
+  feature_a_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  # featureB branch (stacked on featureA)
+  git -C "$repo_path" checkout -qb featureB
+  printf 'featureB\n' >"$repo_path/b.txt"
+  git -C "$repo_path" add b.txt
+  git -C "$repo_path" commit -qm "featureB commit"
+
+  local head_sha prev_head_sha prev_base_sha base_sha
+  head_sha="$(git -C "$repo_path" rev-parse HEAD)"
+  prev_head_sha="$head_sha"
+  prev_base_sha="$feature_a_sha"
+
+  # Squash-merge featureA into main
+  git -C "$repo_path" checkout -q "$trunk_branch"
+  git -C "$repo_path" merge --squash featureA -q
+  git -C "$repo_path" commit -qm "squash merge featureA"
+  base_sha="$(git -C "$repo_path" rev-parse HEAD)"
+
+  # Call the actual function under test — same code path as action.yml
+  local output
+  output="$(run_check_range_diff_stale \
+    --repository-path "$repo_path" \
+    --prev-base-sha "$prev_base_sha" \
+    --prev-head-sha "$prev_head_sha" \
+    --base-sha "$base_sha" \
+    --head-sha "$head_sha")"
+
+  [[ "$output" == "stale=false" ]] ||
+    fail "Expected stale=false when HEAD unchanged after base-branch squash-merge, got: $output"
+}
+
 test_action_uses_github_env_shas_without_redeclaring_them() {
   local range_diff_block merge_tree_block
   range_diff_block="$(extract_step_block "Check if diff has changed")"
@@ -424,6 +532,8 @@ main() {
   test_action_continues_after_approval_lookup_failure
   test_action_run_blocks_do_not_inline_github_context
   test_action_uses_github_env_shas_without_redeclaring_them
+  test_base_branch_advance_is_not_stale
+  test_base_branch_advance_e2e_is_not_stale
 
   echo "dismiss-stale-approvals self-test passed"
 }


### PR DESCRIPTION
## Summary
Fixes false positive stale approval dismissals when only the base branch advances (e.g., squash-merge of a stacked PR).

## Problem

When a stacked PR's base gets squash-merged, the base branch advances but the PR branch is untouched. The shifted merge-base causes `git range-diff` to report false differences:

```
main:       A ─── B ─────────── S (squash merge of featureA)
                   \
featureA:           C (gets squash-merged)
                     \
featureB:             D (approved, untouched)
```

**Before squash-merge (previous run):**
- `PREV_BASE_SHA` = C, `PREV_HEAD_SHA` = D
- `merge-base(C, D)` = C → range: `C..D` (just featureB's commit)

**After squash-merge (current run):**
- `BASE_SHA` = S, `HEAD_SHA` = D (unchanged!)
- `merge-base(S, D)` = B (shifted!) → range: `B..D` (featureA + featureB)

```
range-diff C..D vs B..D:
  -:  ------- > 1:  92ee94d featureA commit    ← false positive!
  1:  404d18d = 2:  404d18d featureB commit
```

## Fix

Extracts the range-diff logic into a testable function `run_check_range_diff_stale` in `range-diff-stale.sh`. The function checks if `HEAD_SHA == PREV_HEAD_SHA` before running `range-diff` — same HEAD SHA = same git content by definition, so the review can't be stale.

The fix lives in the same code that `action.yml` calls, not as an untestable YAML short-circuit.

## Tests

- **Parser test** (`test_base_branch_advance_is_not_stale`): verifies the range-diff parser reports `stale=true` for the shifted merge-base, documenting the false positive
- **E2E test** (`test_base_branch_advance_e2e_is_not_stale`): reproduces the full stacked PR squash-merge scenario, calls `run_check_range_diff_stale` directly, asserts `stale=false`
  - **Fails without the fix** (range-diff false positive → `stale=true`)
  - **Passes with the fix** (HEAD unchanged → `stale=false`)

## Related
- [SRE-637](https://linear.app/hash/issue/SRE-637)
- Observed on [internal-infra PR #187](https://github.com/hashintel/internal-infra/pull/187)