### PR TITLE
H-6447, H-6448, H-6449: Add `nextest`, `rand`, and `reqwest` Rust crates group to Renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -406,6 +406,11 @@
       "matchManagers": ["cargo"],
       "groupName": "`Temporal` Rust crates",
       "matchPackageNames": ["/^temporalio[-_]?/"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "`nextest` Rust crates",
+      "matchPackageNames": ["/^nextest[-_]?/"]
     }
   ],
   "customManagers": [

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -411,11 +411,6 @@
       "matchManagers": ["cargo"],
       "groupName": "`nextest` Rust crates",
       "matchPackageNames": ["/^nextest[-_]?/"]
-    },
-    {
-      "matchManagers": ["cargo"],
-      "groupName": "`rand` Rust crates",
-      "matchPackageNames": ["/^rand[-_]?/"]
     }
   ],
   "customManagers": [

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -416,6 +416,11 @@
       "matchManagers": ["cargo"],
       "groupName": "`rand` Rust crates",
       "matchPackageNames": ["/^rand[-_]?/"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "`reqwest` Rust crates",
+      "matchPackageNames": ["/^reqwest[-_]?/"]
     }
   ],
   "customManagers": [

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -411,6 +411,11 @@
       "matchManagers": ["cargo"],
       "groupName": "`nextest` Rust crates",
       "matchPackageNames": ["/^nextest[-_]?/"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "`rand` Rust crates",
+      "matchPackageNames": ["/^rand[-_]?/"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Adds a Renovate grouping rule to consolidate `nextest`-related Rust crate updates into a single group, same with `rand`-related and `reqwest`-related Rust crate updates, consistent with how other Rust crate families (e.g., `temporalio`) are handled.
