### PR TITLE
H-6451: Add `deadpool` Rust crates group to Renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -421,6 +421,11 @@
       "matchManagers": ["cargo"],
       "groupName": "`reqwest` Rust crates",
       "matchPackageNames": ["/^reqwest[-_]?/"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "groupName": "`deadpool` Rust crates",
+      "matchPackageNames": ["/^deadpool[-_]?/"]
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Adds a Renovate grouping rule for `deadpool` Rust crates, ensuring that `deadpool` and its related crates are batched together into a single update PR rather than receiving separate updates.
