### PR TITLE
SRE 696: Fix stale approvals reusable workflow checkout for PR callers

### DIFF
--- a/.github/workflows/preflight-stale-approvals.yml
+++ b/.github/workflows/preflight-stale-approvals.yml
@@ -34,7 +34,6 @@ jobs:
     steps:
       - name: Resolve reusable workflow ref
         id: workflow-ref
-        if: github.event_name != 'pull_request'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
@@ -44,17 +43,7 @@ jobs:
             const ref = job_workflow_ref.split('@')[1];
             core.setOutput('ref', ref);
 
-      - name: Checkout action from pull request
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          sparse-checkout: |
-            .github/actions/dismiss-stale-approvals
-
-      - name: Checkout action from reusable workflow ref
-        if: github.event_name != 'pull_request'
+      - name: Checkout action
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: hashintel/.github


### PR DESCRIPTION
## Summary

- Always checkout the shared action from `hashintel/.github` instead of the PR head repository
- Remove the split checkout path added in #58 for `pull_request` events
- Always resolve and use the reusable workflow ref as the checkout ref

## Why

PR #58 made `pull_request` events checkout the PR head repository so changes to `.github/actions/dismiss-stale-approvals` could be self-tested before merge. That breaks callers in other repositories because their PR head checkout does not contain `.github/actions/dismiss-stale-approvals/self-test.sh`.

The reusable workflow should run the actual shared action from `hashintel/.github` regardless of which repository triggered the PR event. Now that this branch lives in `hashintel/.github` rather than a fork, the OIDC step can run on `pull_request` events and provide the exact workflow ref for checkout.

## Linear

- SRE-696

## Tests

- `.github/actions/dismiss-stale-approvals/self-test.sh`
