### PR TITLE
SRE-720: Simplify PR-title preflight — drop two-step skip logic

### DIFF
--- a/.github/workflows/preflight-pr-title.yml
+++ b/.github/workflows/preflight-pr-title.yml
@@ -20,16 +20,6 @@ on:
     types: [opened, synchronize, reopened, edited]
   merge_group:
   workflow_call:
-    inputs:
-      ignored-actors:
-        description: |
-          Additional GitHub logins to exempt from the check, as a
-          newline- or comma-separated list. GitHub App accounts
-          (`pull_request.user.type == 'Bot'`) are always skipped, so
-          this is only needed for human accounts that should be exempt.
-        type: string
-        required: false
-        default: ""
 
 permissions:
   contents: read
@@ -38,40 +28,9 @@ jobs:
   check:
     name: Linear Issue ID
     runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.user.type != 'Bot'
     steps:
-      - name: Determine whether to skip the check
-        id: skip
-        env:
-          PR_USER: ${{ github.event.pull_request.user.login }}
-          PR_USER_TYPE: ${{ github.event.pull_request.user.type }}
-          EXTRA_IGNORED: ${{ inputs.ignored-actors }}
-        run: |
-          echo "PR author: $PR_USER (type: $PR_USER_TYPE)"
-
-          if [[ "$PR_USER_TYPE" == "Bot" ]]; then
-            echo "::notice::Skipping check — PR authored by a bot account ($PR_USER)."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [[ -n "$EXTRA_IGNORED" ]]; then
-            EXTRA_NORMALIZED=$(printf '%s' "$EXTRA_IGNORED" \
-              | tr ',' '\n' \
-              | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
-              | sed '/^$/d')
-
-            if echo "$EXTRA_NORMALIZED" | grep -qFx "$PR_USER"; then
-              echo "::notice::Skipping check — PR author $PR_USER is in the ignored-actors list."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
       - name: Validate PR title contains Linear issue ID
-        if: steps.skip.outputs.skip != 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |

--- a/.github/workflows/preflight-pr-title.yml
+++ b/.github/workflows/preflight-pr-title.yml
@@ -5,10 +5,9 @@
 # before the first ":". Mirrors the prefix-parsing convention already used by
 # `preflight-todo-comments.yml`, so the same IDs power both checks.
 #
-# Bot-authored PRs are skipped by default (any account where
+# Bot-authored PRs are skipped (any account where
 # `pull_request.user.type == 'Bot'`, which covers `hash-worker[bot]`,
-# `dependabot[bot]`, and any other GitHub App). Additional user logins can be
-# skipped via the `ignored-actors` input.
+# `dependabot[bot]`, and any other GitHub App).
 name: PR Title
 
 on:


### PR DESCRIPTION
## Summary

- Folds the bot-author check into the job-level `if:`:
  ```yaml
  if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.user.type != 'Bot'
  ```
- Removes the separate `Determine whether to skip` step and the unused `ignored-actors` workflow input.

Same behavior for both human and bot authors; just less moving parts. The `ignored-actors` input was added speculatively in [SRE-715](https://linear.app/hash/issue/SRE-715) and no consumer uses it — trivial to re-add as another `&&` clause if a future case needs to exempt a human account.

Related: [SRE-720](https://linear.app/hash/issue/SRE-720), follow-up to [SRE-715](https://linear.app/hash/issue/SRE-715).

## Test plan

- [ ] Self-PR (this PR touches the workflow file) triggers the workflow and passes (`SRE-720` in title).
- [ ] After merge, a human-authored PR without an ID still fails the check.
- [ ] After merge, a `hash-worker[bot]` / `dependabot[bot]` PR still skips correctly.