### PR TITLE
H-6528: Add approval-freshness check for merge queue events

### DIFF
--- a/.github/actions/dismiss-stale-approvals/action.yml
+++ b/.github/actions/dismiss-stale-approvals/action.yml
@@ -13,6 +13,17 @@ inputs:
     description: Comment on the PR instead of dismissing approvals
     required: false
     default: false
+  pr-number:
+    description: Override the PR number (for merge_group events where context is unavailable)
+    required: false
+  fail-if-stale:
+    description: Exit with non-zero code if approvals are stale (useful for merge queue checks)
+    required: false
+    default: false
+  skip-range-diff:
+    description: Skip the range-diff check (for merge_group where no previous SHAs exist)
+    required: false
+    default: false
 
 outputs:
   stale:
@@ -34,11 +45,12 @@ runs:
         echo "workflow_run_url=$run_url" >> "$GITHUB_OUTPUT"
 
     - name: Download SHAs from last run
+      if: inputs.skip-range-diff != 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         ACTION_PATH: ${{ github.action_path }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_NUMBER: ${{ inputs.pr-number || github.event.pull_request.number }}
         HEAD_REF: ${{ github.head_ref }}
         REPOSITORY: ${{ github.repository }}
         WORKFLOW_NAME: ${{ github.workflow }}
@@ -62,17 +74,27 @@ runs:
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_NUMBER: ${{ inputs.pr-number || github.event.pull_request.number }}
+        GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
-        echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_ENV"
+        if [[ -n "$HEAD_SHA" && -n "$BASE_SHA" ]]; then
+          echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
+          echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_ENV"
+        else
+          pr_data=$(gh pr view "$PR_NUMBER" --json headRefOid,baseRefOid)
+          echo "HEAD_SHA=$(echo "$pr_data" | jq -r '.headRefOid')" >> "$GITHUB_ENV"
+          echo "BASE_SHA=$(echo "$pr_data" | jq -r '.baseRefOid')" >> "$GITHUB_ENV"
+        fi
 
     - name: Write SHAs to file
+      if: inputs.skip-range-diff != 'true'
       shell: bash
       run: |
         echo "$HEAD_SHA" > shas.txt
         echo "$BASE_SHA" >> shas.txt
 
     - name: Upload SHAs
+      if: inputs.skip-range-diff != 'true'
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       continue-on-error: true
       with:
@@ -81,6 +103,7 @@ runs:
 
     - name: Check if diff has changed
       id: range-diff
+      if: inputs.skip-range-diff != 'true'
       continue-on-error: true
       shell: bash
       env:
@@ -121,7 +144,7 @@ runs:
       env:
         ACTION_PATH: ${{ github.action_path }}
         GH_TOKEN: ${{ inputs.github-token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_NUMBER: ${{ inputs.pr-number || github.event.pull_request.number }}
         REPOSITORY: ${{ github.repository }}
       run: |
         approval_sha="$("$ACTION_PATH/latest-approval-sha.sh" "$REPOSITORY" "$PR_NUMBER")"
@@ -187,7 +210,7 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         DRY_RUN: ${{ inputs.dry-run }}
         GH_TOKEN: ${{ inputs.github-token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_NUMBER: ${{ inputs.pr-number || github.event.pull_request.number }}
         REASON: ${{ steps.decision.outputs.reason }}
         REPOSITORY: ${{ github.repository }}
       run: |
@@ -196,4 +219,9 @@ runs:
           --pr-number "$PR_NUMBER" \
           --reason "$REASON" \
           --dry-run "$DRY_RUN"
+
+    - name: Fail if stale
+      if: inputs.fail-if-stale == 'true' && steps.decision.outputs.stale == 'true'
+      shell: bash
+      run: exit 1
 

--- a/.github/actions/dismiss-stale-approvals/action.yml
+++ b/.github/actions/dismiss-stale-approvals/action.yml
@@ -76,12 +76,13 @@ runs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         PR_NUMBER: ${{ inputs.pr-number || github.event.pull_request.number }}
         GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ github.repository }}
       run: |
         if [[ -n "$HEAD_SHA" && -n "$BASE_SHA" ]]; then
           echo "HEAD_SHA=$HEAD_SHA" >> "$GITHUB_ENV"
           echo "BASE_SHA=$BASE_SHA" >> "$GITHUB_ENV"
         else
-          pr_data=$(gh pr view "$PR_NUMBER" --json headRefOid,baseRefOid)
+          pr_data=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json headRefOid,baseRefOid)
           echo "HEAD_SHA=$(echo "$pr_data" | jq -r '.headRefOid')" >> "$GITHUB_ENV"
           echo "BASE_SHA=$(echo "$pr_data" | jq -r '.baseRefOid')" >> "$GITHUB_ENV"
         fi

--- a/.github/actions/dismiss-stale-approvals/action.yml
+++ b/.github/actions/dismiss-stale-approvals/action.yml
@@ -197,7 +197,3 @@ runs:
           --reason "$REASON" \
           --dry-run "$DRY_RUN"
 
-    - name: Fail if approvals are stale
-      if: steps.decision.outputs.stale == 'true'
-      shell: bash
-      run: exit 1

--- a/.github/actions/dismiss-stale-approvals/action.yml
+++ b/.github/actions/dismiss-stale-approvals/action.yml
@@ -196,3 +196,8 @@ runs:
           --pr-number "$PR_NUMBER" \
           --reason "$REASON" \
           --dry-run "$DRY_RUN"
+
+    - name: Fail if approvals are stale
+      if: steps.decision.outputs.stale == 'true'
+      shell: bash
+      run: exit 1

--- a/.github/actions/dismiss-stale-approvals/decide-stale-approvals.sh
+++ b/.github/actions/dismiss-stale-approvals/decide-stale-approvals.sh
@@ -23,7 +23,7 @@ run_decide_stale_approvals() {
   elif [[ "$merge_tree_stale" == "true" ]]; then
     stale="true"
     reason="$merge_tree_reason"
-  elif [[ "$range_diff_outcome" != "success" ]]; then
+  elif [[ "$range_diff_outcome" != "success" && "$range_diff_outcome" != "skipped" ]]; then
     stale="true"
     reason="Failed to check if diff has changed; see action logs at $workflow_run_url"
   elif [[ "$no_prev_shas" == "1" ]]; then

--- a/.github/workflows/preflight-stale-approvals.yml
+++ b/.github/workflows/preflight-stale-approvals.yml
@@ -30,7 +30,6 @@ jobs:
   dismiss:
     name: Dismiss
     runs-on: ubuntu-24.04
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     steps:
       - name: Resolve reusable workflow ref
         id: workflow-ref
@@ -52,40 +51,11 @@ jobs:
             .github/actions/dismiss-stale-approvals
 
       - name: Run self-test
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         run: .github/actions/dismiss-stale-approvals/self-test.sh
 
-      - name: Dismiss stale pull request approvals
-        id: dismiss
-        uses: ./.github/actions/dismiss-stale-approvals
-        with:
-          dry-run: ${{ github.event_name == 'pull_request' }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  check-merge-queue:
-    name: Check merge queue
-    runs-on: ubuntu-24.04
-    if: github.event_name == 'merge_group'
-    steps:
-      - name: Resolve reusable workflow ref
-        id: workflow-ref
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            const token = await core.getIDToken();
-            const [, payload] = token.split('.');
-            const { job_workflow_ref } = JSON.parse(Buffer.from(payload, 'base64url'));
-            const ref = job_workflow_ref.split('@')[1];
-            core.setOutput('ref', ref);
-
-      - name: Checkout action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: hashintel/.github
-          ref: ${{ steps.workflow-ref.outputs.ref }}
-          sparse-checkout: |
-            .github/actions/dismiss-stale-approvals
-
       - name: Extract PR number from merge group ref
+        if: github.event_name == 'merge_group'
         id: pr
         env:
           HEAD_REF: ${{ github.event.merge_group.head_ref }}
@@ -98,10 +68,11 @@ jobs:
             exit 1
           fi
 
-      - name: Check approval freshness
+      - name: Dismiss stale pull request approvals
         uses: ./.github/actions/dismiss-stale-approvals
         with:
+          dry-run: ${{ github.event_name == 'pull_request' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pr-number: ${{ steps.pr.outputs.number }}
-          skip-range-diff: true
-          fail-if-stale: true
+          skip-range-diff: ${{ github.event_name == 'merge_group' }}
+          fail-if-stale: ${{ github.event_name == 'merge_group' }}

--- a/.github/workflows/preflight-stale-approvals.yml
+++ b/.github/workflows/preflight-stale-approvals.yml
@@ -55,7 +55,86 @@ jobs:
         run: .github/actions/dismiss-stale-approvals/self-test.sh
 
       - name: Dismiss stale pull request approvals
+        id: dismiss
         uses: ./.github/actions/dismiss-stale-approvals
         with:
           dry-run: ${{ github.event_name == 'pull_request' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  check-merge-queue:
+    name: Check merge queue
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'merge_group'
+    steps:
+      - name: Resolve reusable workflow ref
+        id: workflow-ref
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const token = await core.getIDToken();
+            const [, payload] = token.split('.');
+            const { job_workflow_ref } = JSON.parse(Buffer.from(payload, 'base64url'));
+            const ref = job_workflow_ref.split('@')[1];
+            core.setOutput('ref', ref);
+
+      - name: Checkout action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: hashintel/.github
+          ref: ${{ steps.workflow-ref.outputs.ref }}
+          sparse-checkout: |
+            .github/actions/dismiss-stale-approvals
+
+      - name: Extract PR number from merge group ref
+        id: pr
+        env:
+          HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        shell: bash
+        run: |
+          if [[ "$HEAD_REF" =~ /pr-([0-9]+)-[a-f0-9]+$ ]]; then
+            echo "number=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Could not extract PR number from merge group ref: $HEAD_REF"
+            exit 1
+          fi
+
+      - name: Read latest approval SHA
+        id: approval
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION_PATH: .github/actions/dismiss-stale-approvals
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          approval_sha="$("$ACTION_PATH/latest-approval-sha.sh" "$REPOSITORY" "$PR_NUMBER")"
+          echo "sha=$approval_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch PR head SHA
+        id: pr-head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        shell: bash
+        run: |
+          head_sha=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
+          echo "sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Check approval freshness
+        env:
+          APPROVAL_SHA: ${{ steps.approval.outputs.sha }}
+          PR_HEAD_SHA: ${{ steps.pr-head.outputs.sha }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        shell: bash
+        run: |
+          if [[ -z "$APPROVAL_SHA" ]]; then
+            echo "::error::PR #$PR_NUMBER has no approvals"
+            exit 1
+          fi
+
+          if [[ "$APPROVAL_SHA" != "$PR_HEAD_SHA" ]]; then
+            echo "::error::PR #$PR_NUMBER has stale approvals (approved at $APPROVAL_SHA, current head is $PR_HEAD_SHA)"
+            exit 1
+          fi
+
+          echo "PR #$PR_NUMBER has fresh approvals (approved at $APPROVAL_SHA)"

--- a/.github/workflows/preflight-stale-approvals.yml
+++ b/.github/workflows/preflight-stale-approvals.yml
@@ -98,43 +98,10 @@ jobs:
             exit 1
           fi
 
-      - name: Read latest approval SHA
-        id: approval
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTION_PATH: .github/actions/dismiss-stale-approvals
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          REPOSITORY: ${{ github.repository }}
-        shell: bash
-        run: |
-          approval_sha="$("$ACTION_PATH/latest-approval-sha.sh" "$REPOSITORY" "$PR_NUMBER")"
-          echo "sha=$approval_sha" >> "$GITHUB_OUTPUT"
-
-      - name: Fetch PR head SHA
-        id: pr-head
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        shell: bash
-        run: |
-          head_sha=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
-          echo "sha=$head_sha" >> "$GITHUB_OUTPUT"
-
       - name: Check approval freshness
-        env:
-          APPROVAL_SHA: ${{ steps.approval.outputs.sha }}
-          PR_HEAD_SHA: ${{ steps.pr-head.outputs.sha }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-        shell: bash
-        run: |
-          if [[ -z "$APPROVAL_SHA" ]]; then
-            echo "::error::PR #$PR_NUMBER has no approvals"
-            exit 1
-          fi
-
-          if [[ "$APPROVAL_SHA" != "$PR_HEAD_SHA" ]]; then
-            echo "::error::PR #$PR_NUMBER has stale approvals (approved at $APPROVAL_SHA, current head is $PR_HEAD_SHA)"
-            exit 1
-          fi
-
-          echo "PR #$PR_NUMBER has fresh approvals (approved at $APPROVAL_SHA)"
+        uses: ./.github/actions/dismiss-stale-approvals
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.pr.outputs.number }}
+          skip-range-diff: true
+          fail-if-stale: true


### PR DESCRIPTION
## Summary

- Adds `approval-freshness` job that runs on `merge_group` events
- Fails if the PR's latest approval SHA doesn't match the current head SHA
- When the check fails, GitHub removes the PR from the merge queue

## Problem

When a PR enters the merge queue, the existing dismiss-stale-approvals workflow runs but does nothing — the `dismiss` job only runs on `pull_request` events. This allowed PRs with stale approvals to merge, causing failures in automated audit tests (e.g., [internal-infra#224](https://github.com/hashintel/internal-infra/pull/224)).

## Solution

Instead of just dismissing reviews (which GitHub ignores once a PR is queued), the new job **fails the check** when approvals are stale. GitHub's merge queue will then remove the PR automatically.

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Test on a PR that enters the merge queue with fresh approvals (should pass)
- [ ] Test on a PR that enters the merge queue with stale approvals (should fail and be removed from queue)

## Note

For full enforcement, the `Stale approvals` workflow (or specifically the `Approval freshness` job) should be added as a **required status check** on protected branches.

Slack thread: https://hashintel.slack.com/archives/C02TWBTT3ED/p1779893853489159?thread_ts=1779891497.054019&cid=C02TWBTT3ED

https://claude.ai/code/session_016iAKAPoe3QeYQydBjGGKZK

---
_Generated by [Claude Code](https://claude.ai/code/session_016iAKAPoe3QeYQydBjGGKZK)_